### PR TITLE
Failfast when MFA is configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,4 @@ mvn apikit-flow-generator:generateFlowRest \
     -Danypoint.password= \
     -DdesignCenter.project.name=
 ```
+_**NOTE:** Anypoint users with MFA enabled or SSO Users are not supported by this plugin._


### PR DESCRIPTION
Authentication process goes in loop when trying to authenticate a user with MFA enabled. This change will cause it to failfast. As of now, MFA enabled users are not supported to by the plugin.