### PR TITLE
feat: refactored out generation of config code vs file writing logic. [MSSPARK-96]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Maven plugin for generating MuleSoft APIKit flows from REST (RAML) or SOAP (WSDL) specifications. The plugin scaffolds Mule 4 flows and configurations automatically.
+
+## Essential Commands
+
+### Building and Testing
+- **Build the plugin**: `mvn clean compile`
+- **Run tests**: `mvn test`
+- **Package the plugin**: `mvn package`
+- **Install locally**: `mvn install`
+- **Release build**: `mvn clean package -Prelease`
+
+### Running the Plugin Goals
+- **Generate REST flows**: `mvn apikit-flow-generator:generateFlowRest`
+- **Generate SOAP flows**: `mvn apikit-flow-generator:generateFlowSoap`
+
+### Testing Plugin Goals Locally
+After building with `mvn install`, test in a target Mule project:
+```bash
+mvn com.avioconsulting.mule:apikit-flow-generator-maven-plugin:generateFlowRest \
+    -Dlocal.raml.directory=/path/to/raml \
+    -Dmain.raml=api.raml
+```
+
+## Code Architecture
+
+### Core Components
+- **RestGenerateMojo.groovy**: Maven goal for REST API flow generation from RAML specs
+- **SoapGenerateMojo.groovy**: Maven goal for SOAP service flow generation from WSDL files
+- **RestGenerator.groovy**: Core logic for REST flow scaffolding using MuleSoft APIKit scaffolder
+- **SoapGenerator.groovy**: Core logic for SOAP flow generation and XML manipulation
+
+### RAML/API Sources Supported
+1. **Local RAML files**: `ramlDirectory` + `ramlFilename`
+2. **Exchange artifacts**: `ramlGroupId` + `ramlArtifactId` (resolved from Maven dependencies)  
+3. **Design Center projects**: `ramlDcProject` + `ramlDcBranch` with Anypoint credentials
+
+### Authentication Methods
+- Username/Password: `anypointUsername` + `anypointPassword`
+- Connected App: `anypointConnectedAppId` + `anypointConnectedAppSecret`
+
+### Key Dependencies
+- **Groovy 3.0.11**: Primary language for plugin implementation
+- **MuleSoft APIKit Scaffolder 2.4.2**: Core scaffolding functionality
+- **WSDL4J 1.6.3**: WSDL parsing for SOAP generation
+- **Apache HttpClient 4.5.14**: HTTP operations for Design Center integration
+
+### Design Center Integration
+- **DesignCenterDeployer.groovy**: Handles API deployment/download from Design Center
+- **HttpClientWrapper.groovy**: Wraps HTTP operations with authentication
+- **RamlFile.groovy**: Represents RAML files from Design Center
+
+### Test Structure
+- Unit tests in `src/test/groovy/` mirror the main source structure
+- Test resources include sample RAML, WSDL, and expected XML output files
+- Uses JUnit 4.13.2 with Hamcrest matchers and XMLUnit for XML comparison
+
+## Maven Plugin Development Notes
+
+This follows standard Maven plugin conventions:
+- Mojos are annotated with `@Mojo(name = 'goalName')`
+- Parameters use `@Parameter(property = 'propertyName')`
+- Extends `AbstractMojo` for logging and execution
+- Uses Groovy instead of Java for implementation
+
+The plugin generates Mule configuration XML files in the target project's `src/main/mule/` directory.

--- a/src/main/groovy/com/avioconsulting/mule/SoapGenerator.groovy
+++ b/src/main/groovy/com/avioconsulting/mule/SoapGenerator.groovy
@@ -7,28 +7,31 @@ import javax.wsdl.factory.WSDLFactory
 
 // Implemented this by hand because the Studio 7.x/Mule 4.x SOAP generator scaffolds have heavy Eclipse dependencies
 class SoapGenerator implements FileUtil {
-    static void generate(File baseDirectory,
-                         File wsdlPath,
-                         String apiName,
-                         String version,
-                         String httpListenerConfigName,
-                         String service,
-                         String port,
-                         boolean insertApiNameInListenerPath,
-                         String insertXmlBeforeRouter = null,
-                         String insertXmlAfterRouter = null) {
-        def mainDir = join(baseDirectory,
-                           'src',
-                           'main')
-        def appDir = join(mainDir,
-                          'mule')
-        def generatedFilenameOnly = "${FilenameUtils.getBaseName(wsdlPath.name)}_${version}.xml"
-        def outputFile = new File(appDir,
-                                  generatedFilenameOnly)
-        if (outputFile.exists()) {
-            // plugin currently duplicates existing files, so don't try and support this
-            throw new Exception('You can only use this plugin to do the initial generation of flows from WSDL. Use Studio to perform updates!')
-        }
+    
+    /**
+     * Generates SOAP configuration content from WSDL file and returns as a Map of filename to content strings.
+     * This method performs the core generation logic without writing files to disk.
+     * 
+     * @param wsdlPath WSDL file to process
+     * @param apiName API name for path generation
+     * @param version API version for path generation
+     * @param httpListenerConfigName HTTP listener configuration reference
+     * @param service WSDL service name
+     * @param port WSDL port name
+     * @param insertApiNameInListenerPath Whether to include API name in listener path
+     * @param insertXmlBeforeRouter Optional XML to insert before router
+     * @param insertXmlAfterRouter Optional XML to insert after router
+     * @return Map where key is the config filename and value is the generated XML content as string
+     */
+    static Map<String, String> generateConfigs(File wsdlPath,
+                                               String apiName,
+                                               String version,
+                                               String httpListenerConfigName,
+                                               String service,
+                                               String port,
+                                               boolean insertApiNameInListenerPath,
+                                               String insertXmlBeforeRouter = null,
+                                               String insertXmlAfterRouter = null) {
         def wsdlFactory = WSDLFactory.newInstance()
         def reader = wsdlFactory.newWSDLReader()
         def definition = reader.readWSDL(wsdlPath.absolutePath)
@@ -57,7 +60,8 @@ class SoapGenerator implements FileUtil {
                             httpListenerConfigName)
                 .replaceAll('THE_LISTENER_PATH',
                             "${newListenerPrefix}/${service}/${port}")
-        outputFile.text = SoapResources.HEADER +
+        
+        def generatedContent = SoapResources.HEADER +
                 '\n' +
                 config +
                 '\n' +
@@ -65,15 +69,52 @@ class SoapGenerator implements FileUtil {
                 '\n' +
                 operationFlows +
                 SoapResources.FOOTER
-        def fileXml = outputFile.text
+        
+        // Apply optional XML insertions
         if (insertXmlBeforeRouter) {
-            fileXml = fileXml.replace('<apikit-soap:router',
+            generatedContent = generatedContent.replace('<apikit-soap:router',
                                       "${insertXmlBeforeRouter}\r\n    <apikit-soap:router")
         }
         if (insertXmlAfterRouter) {
-            fileXml = fileXml.replace('</apikit-soap:router>',
+            generatedContent = generatedContent.replace('</apikit-soap:router>',
                                       "</apikit-soap:router>\r\n    ${insertXmlAfterRouter}")
         }
-        outputFile.text = fileXml
+        
+        def generatedFilenameOnly = "${FilenameUtils.getBaseName(wsdlPath.name)}_${version}.xml"
+        return [(generatedFilenameOnly): generatedContent]
+    }
+    
+    static void generate(File baseDirectory,
+                         File wsdlPath,
+                         String apiName,
+                         String version,
+                         String httpListenerConfigName,
+                         String service,
+                         String port,
+                         boolean insertApiNameInListenerPath,
+                         String insertXmlBeforeRouter = null,
+                         String insertXmlAfterRouter = null) {
+        def mainDir = join(baseDirectory,
+                           'src',
+                           'main')
+        def appDir = join(mainDir,
+                          'mule')
+        def generatedFilenameOnly = "${FilenameUtils.getBaseName(wsdlPath.name)}_${version}.xml"
+        def outputFile = new File(appDir,
+                                  generatedFilenameOnly)
+        if (outputFile.exists()) {
+            // plugin currently duplicates existing files, so don't try and support this
+            throw new Exception('You can only use this plugin to do the initial generation of flows from WSDL. Use Studio to perform updates!')
+        }
+        
+        // Generate configs using the new method
+        def configMap = generateConfigs(wsdlPath, apiName, version, httpListenerConfigName,
+                                        service, port, insertApiNameInListenerPath,
+                                        insertXmlBeforeRouter, insertXmlAfterRouter)
+        
+        // Write the generated content to file
+        configMap.each { filename, content ->
+            new File(appDir, filename).text = content
+        }
     }
 }


### PR DESCRIPTION
Refactored both RestGenerator and SoapGenerator to separate the generation logic from the file writing logic.

  **Summary of Changes**

  RestGenerator.groovy:

  - New method generateConfigs(): Returns Map<String, String> where keys are filenames and values are generated XML content
  - Updated generate() method: Now uses generateConfigs() internally and handles file writing
  - New helper methods: alterMainConfigContent() and alterGlobalConfigContent() that work with string content instead of files

  SoapGenerator.groovy:

  - New method generateConfigs(): Returns Map<String, String> with generated SOAP configuration content
  - Updated generate() method: Now uses generateConfigs() internally and handles file writing
